### PR TITLE
Doc 1833 deprecate notice for graph pattern pages

### DIFF
--- a/modules/graphstudio/nav.adoc
+++ b/modules/graphstudio/nav.adoc
@@ -12,7 +12,7 @@
 *** xref:explore-graph/find-paths-between-vertices.adoc[]
 *** xref:explore-graph/run-gsql-queries.adoc[]
 *** xref:explore-graph/augment-visualization-result.adoc[]
-** Build Graph Patterns
+** Build Graph Patterns (Deprecated)
 *** xref:build-graph-patterns/visual-query-builder-overview.adoc[]
 *** xref:build-graph-patterns/visual-pattern-examples.adoc[]
 ** xref:write-queries.adoc[]

--- a/modules/graphstudio/pages/build-graph-patterns/visual-pattern-examples.adoc
+++ b/modules/graphstudio/pages/build-graph-patterns/visual-pattern-examples.adoc
@@ -1,5 +1,8 @@
 = Visual Pattern Examples
 
+IMPORTANT: In our ongoing efforts to refine and optimize GraphStudio, Build Graph Patterns will begin deprecation as of v3.9.3 and will not be supported in future versions of GraphStudio.
+Please visit our Insights documentation on xref:3.7@insights:widgets:index.adoc[] for graph and results visualization.
+
 You have learnt all the basic concepts of the Visual Query Builder in the previous article. In this article we will walk you through building several visual patterns step by step, and then show you more graph analytics questions and how to solve them with visual patterns.‌
 
 == Example 1. Find all the departments with male employees

--- a/modules/graphstudio/pages/build-graph-patterns/visual-query-builder-overview.adoc
+++ b/modules/graphstudio/pages/build-graph-patterns/visual-query-builder-overview.adoc
@@ -1,5 +1,8 @@
 = Visual Query Builder
 
+IMPORTANT: In our ongoing efforts to refine and optimize GraphStudio, Build Graph Patterns will begin deprecation as of v3.9.3 and will not be supported in future versions of GraphStudio.
+Please visit our Insights documentation on xref:3.7@insights:widgets:index.adoc[] for graph and results visualization.
+
 The Visual Query Builder (VQB), found on the Build Graph Patterns page, provides a visual approach to exploring your graph and using it to solve problems.
 Here, you can create visual patterns by dragging and dropping vertices and edges to represent the questions you want to ask instead of writing GSQL queries.
 


### PR DESCRIPTION
Assorted task: https://graphsql.atlassian.net/browse/DOC-1833 

This PR adds the deprecation notice to the two pages in Build Graph Patterns:

1) it reads as an IMPORTANT tag and encourages user to explore the widgets of Insights features, as these provide graph and results visualization support.

IMPORTANT: In our ongoing efforts to refine and optimize GraphStudio, Build Graph Patterns will begin deprecation as of v3.9.3 and will not be supported in future versions of GraphStudio. Please visit our Insights documentation on xref:3.7@insights:widgets:index.adoc[] for graph and results visualization.